### PR TITLE
fix: newly added Block Grid area blocks never render a preview (#322) [v5]

### DIFF
--- a/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts
+++ b/src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts
@@ -177,11 +177,12 @@ export class BlockGridPreviewCustomView extends BlockPreviewBaseElement<BlockGri
                         };
                         this._blockContext.blockIndex = (contents ?? []).findIndex(x => x.key === this._blockContext.contentUdi);
                         if (!this._htmlMarkup && !this._isLoading) {
-                            // Defer render if areas are expected but layoutAreas haven't arrived yet;
-                            // observeBlockValue will trigger the render once layoutAreas are available.
-                            if ((this._blockContext.areas?.length ?? 0) > 0 && !this._blockContext.layoutAreas) {
-                                return;
-                            }
+                            // Don't defer on missing layoutAreas: a newly added, unsaved block has
+                            // no `areas` entry on its layout at all (#322) and layoutAreas never
+                            // arrives until content is added to an area or the document is saved.
+                            // #filterLayouts() already defaults each area's items to [], so this
+                            // renders correctly empty; observeBlockValue re-renders once real
+                            // layoutAreas data does arrive (#293).
                             this.renderBlockPreview();
                         }
                     }

--- a/src/Umbraco.Community.BlockPreview/wwwroot/App_Plugins/Umbraco.Community.BlockPreview/index.js
+++ b/src/Umbraco.Community.BlockPreview/wwwroot/App_Plugins/Umbraco.Community.BlockPreview/index.js
@@ -1139,8 +1139,6 @@ Ze = async function() {
           expose: s ?? [],
           layout: { "Umbraco.BlockGrid": M(this, B, ne).call(this) }
         }, this._blockContext.blockIndex = (e ?? []).findIndex((n) => n.key === this._blockContext.contentUdi), !this._htmlMarkup && !this._isLoading) {
-          if ((this._blockContext.areas?.length ?? 0) > 0 && !this._blockContext.layoutAreas)
-            return;
           this.renderBlockPreview();
         }
       }


### PR DESCRIPTION
## Summary

Backports the v6 fix (#333) for #322 to the v5 line — a newly added, unsaved Block Grid block with areas never renders a preview.

This is very likely the cause of the two follow-up reports on #322: one user hit the bug on 5.5.0/Umbraco 17.6.0, and confirmed downgrading to 5.4.1 fixed it. `v5/main` (5.5.0) still has the defer guard described below; it predates 5.4.1 or was reintroduced by the #293 fix and has never been corrected on this line.

**Root cause**: Umbraco's `UmbBlockGridEntryContext` derives `layoutAreas` as `layout?.areas`. A brand-new block is created with an empty `partialLayoutEntry: {}`, so its layout entry has no `areas` key at all — `layoutAreas` stays `undefined` until content is added into an area or the document is saved and reloaded.

The #293 fix added a guard that deferred the initial preview render whenever a block had configured areas but `layoutAreas` hadn't arrived yet, to avoid a transient incomplete render. For brand-new blocks that guard never releases, so the preview stays permanently blank and the area's "Add new Layout" button (part of the server-rendered markup) is unreachable.

**Fix**: Removed the defer/early-return in `#observeBlockPropertyValue`, identical to the v6 fix. `#filterLayouts()` already defaults each area's `items` to `[]` when `layoutAreas` is missing, so rendering immediately is safe and correct for new blocks. The existing re-render trigger in `observeBlockValue` (fired when `layoutAreas` transitions from absent to present) is untouched, so the #293 fix for saved blocks with a content/settings-vs-layoutAreas race is preserved.

- `src/Umbraco.Community.BlockPreview.UI/src/blockEditor/block-grid-preview.custom-view.element.ts` — remove the defer guard
- `wwwroot/App_Plugins/.../index.js` — hand-patched to match (see note below)

## Note on the build

This environment's outbound network access to the Umbraco prerelease npm registry (`myget.org`) is blocked by org policy, so `npm run build` could not be run to regenerate the bundle here. Unlike the v6 fix, there was no existing PR with a pre-built bundle for this exact change to reuse, so the compiled `index.js` was hand-patched to mirror the source diff exactly — the built output for this file is unminified/readable enough that the change is a direct, verifiable 1:1 match of the TS diff (confirmed via `node --check`). The corresponding sourcemap was **not** regenerated and is now slightly stale for this file. A maintainer with build access should run `npm run build` to produce a clean bundle + sourcemap before release.

## Test plan

- [x] `node --check` on the hand-patched bundle passes
- [ ] Maintainer: run `npm run build` to regenerate a clean bundle/sourcemap
- [ ] Manual verification in the test site: add a new area-carrying block to a Block Grid property without saving and confirm the preview renders with the "Add new Layout" button, and that existing saved blocks with area content still render correctly (#293 regression check)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3ybE1j7L5X32L7k4mvgYz)_