### PR TITLE
docs: correct the release trigger and v5 references in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md - BlockPreview v5
+# CLAUDE.md - BlockPreview v6
 
 ## Overview
 
@@ -9,7 +9,7 @@
 - TypeScript/Lit - Frontend UI components (Umbraco backoffice extension)
 - Vite - Frontend build tooling
 
-**Target Platform:** Umbraco CMS v17+
+**Target Platform:** Umbraco CMS v18+
 
 **Package:** [Umbraco.Community.BlockPreview on NuGet](https://www.nuget.org/packages/Umbraco.Community.BlockPreview)
 
@@ -22,7 +22,7 @@
   /Umbraco.Community.BlockPreview       - Main .NET library (RCL)
   /Umbraco.Community.BlockPreview.UI    - TypeScript frontend (Lit components)
 /examples               - Example/test sites
-  /Umbraco.Community.BlockPreview.TestSite  - Umbraco 17 test site
+  /Umbraco.Community.BlockPreview.TestSite  - Umbraco 18 test site
 /tools                  - Build utilities
   /Umbraco.Community.BlockPreview.SchemaGenerator - JSON schema generator
 /docs                   - Documentation
@@ -77,21 +77,30 @@ Test site credentials:
 
 Uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) for automatic versioning.
 
-- Version defined in `version.json` (currently `5.0.0`)
-- Release tags: `release-{version}` (e.g., `release-5.0.0`)
+- Version defined in `version.json`
+- Release tags: `release-{version}` (e.g., `release-6.1.1`)
 - Release branches: `release/{version}`
+
+**Cutting a release:**
+1. Branch `release/{version}` off `v6/dev`.
+2. Set the version in `version.json`, `src/Umbraco.Community.BlockPreview.UI/package.json`, and `package-lock.json`. Run `npm run build` so the package manifest restamps.
+3. PR that branch into `v6/main` and merge.
+4. Tag `release-{version}` on `v6/main` and push the tag. **The tag is what publishes.**
+
+The published version comes from `version.json` on the tagged commit, not from the tag name. Keep the two in step.
 
 ---
 
 ## Teamwork & Collaboration
 
 **Branching:**
-- Main branch: `v5/main`
-- Development branch: `v5/dev`
-- Feature branches merged via PR to `v5/dev`
+- Main branch: `v6/main`
+- Development branch: `v6/dev`
+- Feature branches merged via PR to `v6/dev`
+- The `v5/*` branches are a parallel line for Umbraco 17. Fixes that apply to both are ported across.
 
 **CI/CD:**
-- `release.yml` - Builds and pushes to NuGet on `release-*` tags or `release/*` branches
+- `release.yml` - Builds and pushes to NuGet. Triggers on `release-*` **tags only**, plus manual dispatch. Pushing a `release/*` branch does *not* publish; that trigger was removed in 6a4fc7c because cutting a release created both a branch and a tag and fired the publish twice.
 - `codeql.yml` - Security scanning
 
 **Contributing:** See `.github/CONTRIBUTING.md`


### PR DESCRIPTION
Ports #338 to the v6 line, and fixes the v5 references this file inherited when v6 was branched.

## The release trigger (the port)

CLAUDE.md said `release.yml` fires on `release-*` tags **or** `release/*` branches. The branch trigger was removed in 6a4fc7c, so pushing a release branch publishes nothing. Also adds the four-step release procedure and notes that the published version comes from `version.json` on the tagged commit, not the tag name.

## The v5 references (found while porting)

This file is a straight copy of the v5 one and still describes the v5 line. On `v6/dev` that is actively misleading, so it's corrected here rather than left for later:

| Was | Now |
|---|---|
| `# CLAUDE.md - BlockPreview v5` | `BlockPreview v6` |
| Target Platform: Umbraco CMS v17+ | v18+ |
| Main branch: `v5/main` | `v6/main` |
| Development branch: `v5/dev` | `v6/dev` |
| TestSite described as Umbraco 17 | Umbraco 18 |

Also adds a line noting `v5/*` is the parallel Umbraco 17 line that fixes get ported across, since that isn't obvious from either branch alone.

Verified against `Directory.Build.props` (`UmbracoCmsPackageVersion` is `[18.0.0, 19.0.0)` here, `[17.3.0, 18.0.0)` on v5) and the test site's pinned `Umbraco.Cms` 18.0.0.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
